### PR TITLE
bug 409 conflict on lifecyclerule

### DIFF
--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -33,6 +33,14 @@
     <Reference Include="AWSSDK">
       <HintPath>..\packages\AWSSDK.2.3.15.0\lib\net45\AWSSDK.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.5.1.3\lib\net45\NServiceBus.Core.dll</HintPath>
@@ -50,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="when_creating_queues.cs" />
     <Compile Include="when_parsing_connection_string.cs" />
     <Compile Include="when_sending_messages.cs" />
   </ItemGroup>

--- a/src/NServiceBus.AmazonSQS.Tests/packages.config
+++ b/src/NServiceBus.AmazonSQS.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AWSSDK" version="2.3.15.0" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Moq" version="4.5.30" targetFramework="net45" />
   <package id="NServiceBus" version="5.1.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/NServiceBus.AmazonSQS.Tests/when_creating_queues.cs
+++ b/src/NServiceBus.AmazonSQS.Tests/when_creating_queues.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Net;
-    using Amazon.AWSSupport.Model;
     using Amazon.Runtime;
     using Amazon.S3;
     using Amazon.S3.Model;
@@ -99,7 +98,7 @@
             var bucketName = Guid.NewGuid().ToString();
             var address = new Address(Guid.NewGuid().ToString(), null);
 
-            var mockS3Client = GetMockS3Client(bucketName, SqsQueueCreator.MaxS3BucketRetries+1);
+            var mockS3Client = GetMockS3Client(bucketName, SqsQueueCreator.MaxS3BucketRetries);
             var mockSqsClient = GetMockSqsClient();
 
             var sut = GetQueueCreator(mockS3Client.Object, mockSqsClient.Object, bucketName);

--- a/src/NServiceBus.AmazonSQS.Tests/when_creating_queues.cs
+++ b/src/NServiceBus.AmazonSQS.Tests/when_creating_queues.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AmazonSQS.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Amazon.AWSSupport.Model;
+    using Amazon.Runtime;
+    using Amazon.S3;
+    using Amazon.S3.Model;
+    using Amazon.SQS;
+    using Amazon.SQS.Model;
+    using Moq;
+    using NServiceBus.Transports.SQS;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class when_creating_queues
+    {
+
+        private Mock<IAmazonS3> GetMockS3Client(string bucketName, int conflictAttempts = 1)
+        {
+            var mockS3Client = new Mock<IAmazonS3>();
+            mockS3Client.Setup(s3 => s3.ListBuckets()).Returns(new ListBucketsResponse
+            {
+                Buckets = new List<S3Bucket> { new S3Bucket() { BucketName = bucketName, CreationDate = DateTime.Now } }
+            });
+            mockS3Client.Setup(s3 => s3.PutBucket(It.Is<PutBucketRequest>(r => r.BucketName == bucketName)));
+            mockS3Client.Setup(s3 => s3.GetLifecycleConfiguration(It.Is<GetLifecycleConfigurationRequest>(r => r.BucketName == bucketName))).Returns(new GetLifecycleConfigurationResponse
+            {
+                Configuration = new LifecycleConfiguration()
+            });
+
+            var attemptCount = 0;
+
+            mockS3Client.Setup(s3 => s3.PutLifecycleConfiguration(It.IsAny<PutLifecycleConfigurationRequest>())).Callback(() =>
+            {
+                if (attemptCount >= conflictAttempts)
+                {
+                    return;
+                }
+                attemptCount++;
+                throw new AmazonS3Exception("A conflicting conditional operation is currently in progress against this resource. Please try again.", ErrorType.Sender, "409", Guid.NewGuid().ToString(), HttpStatusCode.Conflict);
+            });
+            return mockS3Client;
+        }
+
+        private Mock<IAmazonSQS> GetMockSqsClient()
+        {
+            var mockSqsClient = new Mock<IAmazonSQS>();
+            mockSqsClient.Setup(sqs => sqs.CreateQueue(It.IsAny<CreateQueueRequest>())).Returns(new CreateQueueResponse
+            {
+                HttpStatusCode = HttpStatusCode.Created,
+                QueueUrl = "https://" + Guid.NewGuid()
+            });
+            mockSqsClient.Setup(sqs => sqs.SetQueueAttributes(It.IsAny<SetQueueAttributesRequest>()));
+            return mockSqsClient;
+        }
+
+        private SqsQueueCreator GetQueueCreator(IAmazonS3 s3Client, IAmazonSQS sqsClient, string bucketName)
+        {
+            return new SqsQueueCreator
+            {
+                ConnectionConfiguration = new SqsConnectionConfiguration
+                {
+                    Region = Amazon.RegionEndpoint.APSoutheast2,
+                    S3BucketForLargeMessages = bucketName
+                },
+                S3Client = s3Client,
+                SqsClient = sqsClient
+            };
+        }
+
+        [Test]
+        public void succeeds_when_conflict_on_first_attempt()
+        {
+
+            // Arrange
+            var bucketName = Guid.NewGuid().ToString();
+            var address = new Address(Guid.NewGuid().ToString(), null);
+
+            var mockS3Client = GetMockS3Client(bucketName);
+            var mockSqsClient = GetMockSqsClient();
+
+            var sut = GetQueueCreator(mockS3Client.Object, mockSqsClient.Object, bucketName);
+
+
+            // Act
+            sut.CreateQueueIfNecessary(address, null);
+
+            // Assert
+            Assert.Pass();
+
+        }
+
+        [Test]
+        public void throws_when_conflict_on_max_retry_attempts()
+        {
+            // Arrange
+            var bucketName = Guid.NewGuid().ToString();
+            var address = new Address(Guid.NewGuid().ToString(), null);
+
+            var mockS3Client = GetMockS3Client(bucketName, SqsQueueCreator.MaxS3BucketRetries+1);
+            var mockSqsClient = GetMockSqsClient();
+
+            var sut = GetQueueCreator(mockS3Client.Object, mockSqsClient.Object, bucketName);
+
+            // Act && Assert
+            Assert.Throws<AmazonS3Exception>(() => sut.CreateQueueIfNecessary(address, null));
+
+            
+        }
+    }
+}

--- a/src/NServiceBus.AmazonSQS.sln.DotSettings
+++ b/src/NServiceBus.AmazonSQS.sln.DotSettings
@@ -154,7 +154,8 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/JavaScriptFormatOther/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
+&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;Or&gt;&#xD;
@@ -165,77 +166,67 @@
             &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
-        &lt;HasAttribute Name="System.Runtime.InteropServices.StructLayoutAttribute" /&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
       &lt;/Or&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&#xD;
   &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="true" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="true" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
       &lt;/And&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
           &lt;Or&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="true" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
-          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" Inherited="false" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Delegate" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Enum" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -246,17 +237,10 @@
           &lt;/And&gt;&#xD;
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind&gt;&#xD;
-          &lt;Kind.Order&gt;&#xD;
-            &lt;DeclarationKind&gt;Constant&lt;/DeclarationKind&gt;&#xD;
-            &lt;DeclarationKind&gt;Field&lt;/DeclarationKind&gt;&#xD;
-          &lt;/Kind.Order&gt;&#xD;
-        &lt;/Kind&gt;&#xD;
+        &lt;Kind Order="Constant Field" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
@@ -266,23 +250,19 @@
           &lt;/Not&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Constructor" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Static/&gt;&#xD;
+        &lt;Static /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -291,30 +271,25 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
           &lt;ImplementsInterface /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;ImplementsInterface Immediate="true" /&gt;&#xD;
+        &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Type" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&lt;/Patterns&gt;&#xD;
-</s:String>
+&lt;/Patterns&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
 &#xD;
 &lt;!--&#xD;
@@ -580,9 +555,13 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	

--- a/src/NServiceBus.AmazonSQS/Extensions/S3Extensions.cs
+++ b/src/NServiceBus.AmazonSQS/Extensions/S3Extensions.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AmazonSQS.Extensions
+{
+    using System;
+    using System.Linq;
+    using Amazon.S3;
+
+    public static class S3Extensions
+    {
+        public static bool DoesS3BucketExist(this IAmazonS3 s3Client, string bucketName)
+        {
+            var listBucketsResponse = s3Client.ListBuckets();
+            return listBucketsResponse.Buckets.Any(x => string.Equals(x.BucketName, bucketName, StringComparison.CurrentCultureIgnoreCase));
+        }
+    }
+}

--- a/src/NServiceBus.AmazonSQS/Extensions/S3LifecycleConfigurationExtensions.cs
+++ b/src/NServiceBus.AmazonSQS/Extensions/S3LifecycleConfigurationExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.AmazonSQS.Extensions
+{
+    using System.Linq;
+    using Amazon.S3.Model;
+
+    public static class S3LifecycleConfigurationExtensions
+    {
+        public static bool ContainsMatchingRule(this LifecycleConfiguration lifeCycleConfiguration, LifecycleRule rule)
+        {
+            return lifeCycleConfiguration.Rules.Any(r => r.Id == rule.Id && r.Prefix == rule.Prefix && r.Status == rule.Status && r.Expiration.Matches(rule.Expiration));
+        }
+    }
+}

--- a/src/NServiceBus.AmazonSQS/Extensions/S3LifecycleRuleExpirationExtensions.cs
+++ b/src/NServiceBus.AmazonSQS/Extensions/S3LifecycleRuleExpirationExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AmazonSQS.Extensions
+{
+    using Amazon.S3.Model;
+
+    public static class S3LifecycleRuleExpirationExtensions
+    {
+        public static bool Matches(this LifecycleRuleExpiration expiration1, LifecycleRuleExpiration expiration2)
+        {
+            if (expiration1 == expiration2)
+            {
+                return true;
+            }
+
+            if (expiration1 == null || expiration2 == null)
+            {
+                return false;
+            }
+
+            return expiration1.Date == expiration2.Date && expiration1.Days == expiration2.Days;
+        }
+    }
+}

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Configure\SqsTransport.cs" />
     <Compile Include="Configure\SqsTransportFeature.cs" />
     <Compile Include="Extensions\AddressExtensions.cs" />
+    <Compile Include="Extensions\S3Extensions.cs" />
+    <Compile Include="Extensions\S3LifecycleConfigurationExtensions.cs" />
+    <Compile Include="Extensions\S3LifecycleRuleExpirationExtensions.cs" />
     <Compile Include="Extensions\SettingsExtensions.cs" />
     <Compile Include="Extensions\SqsMessageExtensions.cs" />
     <Compile Include="AwsClientFactory.cs" />

--- a/src/NServiceBus.AmazonSQS/SqsQueueCreator.cs
+++ b/src/NServiceBus.AmazonSQS/SqsQueueCreator.cs
@@ -52,7 +52,7 @@
             }
         }
 
-        private const int MaxS3BucketRetries = 3;
+        public const int MaxS3BucketRetries = 3;
 
         private void CreateS3ResourcesIfNecessary(int attemptCount = 0)
         {


### PR DESCRIPTION
**Note:** Please don't merge immediately - PR created for review, whilst proceeding with live testing.  Will advise when ready to merge.

Written to address #50, but looking at the history may also address #21.

As per the error response message from amazon, retry the lifecycle rule put operation in case of a conflict response.

* Get the lifecycle rule first to avoid the put operation if not needed (likely to be the case if there was a conflict due to multiple servers starting at the same time, or if the rule has been previously created)
* In case of conflict, retry up to 5 times, with linear backoff wait between retries (250ms * attemptCount)
* Throw original exception if unable to successfully put the rule after 5 attempts.

**Notes:**

* Have not been able to execute integration and acceptance tests in my local environment.  Hoping that the creation of this PR will trigger some automated test runs.  If they don't, let me know and I'll do a bit more to setup local environment and ensure they can execute before you merge.
* Included the Moq library in the NServiceBus.AmazonSQS.Tests project to facilitate mocking a 409 Conflict response for unit testing